### PR TITLE
Purpose and AI-specific tags added

### DIFF
--- a/capability-context/main.tf
+++ b/capability-context/main.tf
@@ -19,6 +19,10 @@ module "resourcegroup" {
     "dfds.cost.centre"          = var.costcentre
     "dfds.service.availability" = var.availability
     "dfds.planned_sunset"       = local.end_date
+    "dfds.purpose"              = var.purpose
+    "dfds.catalogue_id"         = var.catalogue_id
+    "dfds.risk"                 = var.risk
+    "dfds.gdpr"                 = var.gdpr
   }
   start_date = local.start_date
   end_date = local.end_date

--- a/capability-context/variables.tf
+++ b/capability-context/variables.tf
@@ -66,7 +66,22 @@ variable "availability" {
   type        = string
 }
 
-variable "planned_sunset" {
+variable "purpose" {
+  description = "input from the manifest"
+  type        = string
+}
+
+variable "catalogue_id" {
+  description = "input from the manifest"
+  type        = string
+}
+
+variable "risk" {
+  description = "input from the manifest"
+  type        = string
+}
+
+variable "gdpr" {
   description = "input from the manifest"
   type        = string
 }


### PR DESCRIPTION
# Change Request 
https://dfds.sharepoint.com/:w:/r/sites/CloudEngineering/_layouts/15/Doc.aspx?sourcedoc=%7B368C71A4-6741-4A4E-BF37-BB456D1002EA%7D&file=Change%20request%20for%20better%20facilitated%20AI%20resource%20creation%20workflow.docx&action=default&mobileredirect=true

# New tags
- Purpose
- CatalogueId
- Risk
- GDPR

# Notes
We are no longer sending sunset date, so I removed it from the variables but not from main.tf, as it seems you are setting that from other sources currently anyway.